### PR TITLE
Added luaossl to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ## Build plugin
 ARG KONG_VERSION
-FROM docker.io/kong:${KONG_VERSION} as builder
+FROM docker.io/kong:${KONG_VERSION} AS builder
 
 # Root needed to install dependencies
 USER root
@@ -28,5 +28,13 @@ COPY --from=builder /tmp/*.rock /tmp/
 # Root needed for installing plugin
 USER root
 
+# gcc & musl-dev install and uninstall has to be in one layer, to save space
+RUN apk add --no-cache gcc musl-dev && \
+      luarocks install luaossl OPENSSL_DIR=/usr/local/kong CRYPTO_DIR=/usr/local/kong && \
+      apk del --no-cache gcc musl-dev
+
 ARG PLUGIN_VERSION
 RUN luarocks install /tmp/kong-plugin-jwt-keycloak-${PLUGIN_VERSION}.all.rock
+
+USER kong
+


### PR DESCRIPTION
Hi all!

Adding this PR here as requested.

We tried using a higher PostgreSQL version than 13.x and it turns out a dependency was removed from the 2.8.x Kong images: https://github.com/Kong/kong/issues/8259#issuecomment-1004734973

Due to this I added back the luaossl package, with deleting it's dependencies to keep Kong image small. Now it works with postgres 14.x and 15.x

Some notes why the apk and luarocks installs are in one run command:
Docker takes a keyword as one layer, so in the same place where we introuduce a lot of build dependencies we also need to clear them up. This way the final image will be smaller, without the gcc packege.