### PR TITLE
fix: ensure error message formatting with tostring conversion

### DIFF
--- a/src/handler.lua
+++ b/src/handler.lua
@@ -507,7 +507,7 @@ local function do_authentication(conf)
         local ok, _ = custom_match_consumer(conf, jwt)
         if not ok then
             security_event('ua207', 'ua, consumer_match failed') -- this case practically does not occur in the current rover configuration (because consumer_match not used)
-            return ok, err
+            return false, { status = 403, message = "Consumer match failed" }
         end
     end
 
@@ -541,7 +541,7 @@ local function do_authentication(conf)
 
     return false, {
         status = 403,
-        message = "Access token does not have the required scope/role: " .. err
+        message = "Access token does not have the required scope/role: " .. tostring(err)
     }
 end
 


### PR DESCRIPTION
When do_authentication returned false without an error table, the access handler would crash with attempt to index local 'err' (a nil value).

Two code paths could produce false, nil:

consumer_match failure discarded the error from custom_match_consumer and returned the uninitialized outer err variable
Role/scope validation cascade could leave err as nil if an intermediate validator returned false, nil, causing a nil concatenation in the final error message
Changes:

Return a proper { status = 403, message = "Consumer match failed" } error table when consumer_match fails instead of the uninitialized err
Use tostring(err) in the final scope/role error message to guard against nil concatenation