### PR TITLE
Replace blocking socket.http with non-blocking resty.http for JWKS fetching

### DIFF
--- a/.github/workflows/reuse-compliance.yml
+++ b/.github/workflows/reuse-compliance.yml
@@ -12,6 +12,6 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
       - name: REUSE Compliance Check
-        uses: fsfe/reuse-action@v5
+        uses: fsfe/reuse-action@676e2d560c9a403aa252096d99fcab3e1132b0f5 #v6.0.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
       KONG_VERSION: ${{ matrix.kong_version }}
       KEYCLOAK_VERSION: ${{ matrix.keycloak_version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
         with:
           submodules: "true"
       

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ RUN if [ -x "$(command -v apk)" ]; then apk add --no-cache $FIX_DEPENDENCIES; \
     elif [ -x "$(command -v apt-get)" ]; then apt-get remove --purge -y $FIX_DEPENDENCIES; \
     fi
 
-ARG PLUGIN_VERSION=1.7.0-1
+ARG PLUGIN_VERSION=1.8.0-1
 RUN luarocks install /tmp/kong-plugin-jwt-keycloak-${PLUGIN_VERSION}.all.rock
 
 USER kong

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 # Kong Plugin jwt-keycloak
 
 > **⚠️ This fork is a continuation of https://github.com/telekom-digioss/kong-plugin-jwt-keycloak for a limited set of
-version combinations**
+> version combinations**
 >
 > The official author of the plugin no longer maintains it since 24.08.2021  
 > Details see: <https://github.com/gbbirkisson/kong-plugin-jwt-keycloak/blob/master/README.md>
@@ -20,12 +20,12 @@ that are specifically allowed for each endpoint.
 
 The biggest advantages of this plugin are that it supports:
 
-* Rotating public keys
-* Authorization based on token claims:
-    * `scope`
-    * `realm_access`
-    * `resource_access`
-* Matching Keycloak users/clients to Kong consumers
+- Rotating public keys
+- Authorization based on token claims:
+  - `scope`
+  - `realm_access`
+  - `resource_access`
+- Matching Keycloak users/clients to Kong consumers
 
 If you have any suggestion or comments, please feel free to open an issue on this GitHub page.
 
@@ -34,46 +34,46 @@ If you have any suggestion or comments, please feel free to open an issue on thi
 - [Table of Contents](#table-of-contents)
 - [Tested and working for](#tested-and-working-for)
 - [Installation](#installation)
-    - [Using luarocks](#using-luarocks)
-    - [From source](#from-source)
-        - [Packing the rock](#packing-the-rock)
-        - [Installing the rock](#installing-the-rock)
-    - [Enabling plugin](#enabling-plugin)
-    - [Changing plugin priority](#changing-plugin-priority)
-    - [Examples](#examples)
+  - [Using luarocks](#using-luarocks)
+  - [From source](#from-source)
+    - [Packing the rock](#packing-the-rock)
+    - [Installing the rock](#installing-the-rock)
+  - [Enabling plugin](#enabling-plugin)
+  - [Changing plugin priority](#changing-plugin-priority)
+  - [Examples](#examples)
 - [Usage](#usage)
-    - [Enabling on endpoints](#enabling-on-endpoints)
-        - [Service](#service)
-        - [Route](#route)
-        - [Globally](#globally)
-    - [Parameters](#parameters)
-    - [Example](#example)
-    - [Caveats](#caveats)
+  - [Enabling on endpoints](#enabling-on-endpoints)
+    - [Service](#service)
+    - [Route](#route)
+    - [Globally](#globally)
+  - [Parameters](#parameters)
+  - [Example](#example)
+  - [Caveats](#caveats)
 - [Testing](#testing)
-    - [Setup before tests](#setup-before-tests)
-    - [Running tests](#running-tests)
+  - [Setup before tests](#setup-before-tests)
+  - [Running tests](#running-tests)
 
 ## Tested and working for
 
 There are a few limitations about testing combinations:
 
-* Due to the nature of the test setup, we can only test a multitude of Kong versions with a limited set of 
+- Due to the nature of the test setup, we can only test a multitude of Kong versions with a limited set of
   rather recent Keycloak versions.
 
 | Kong Version | Keycloak Version | Passing |
-|--------------|:----------------:|:-------:|
-| 2.8.3        |       26.0       |    ✅    |
-| 2.8.3        |       26.3       |    ✅    |
-| 3.0          |       26.0       |    ✅    |
-| 3.0          |       26.3       |    ✅    |
-| 3.4          |       26.0       |    ✅    |
-| 3.4          |       26.3       |    ✅    |
-| 3.5          |       26.0       |    ✅    |
-| 3.5          |       26.3       |    ✅    |
-| 3.8          |       26.0       |    ✅    |
-| 3.8          |       26.3       |    ✅    |
-| 3.9.1        |       26.0       |    ✅    |
-| 3.9.1        |       26.3       |    ✅    |
+| ------------ | :--------------: | :-----: |
+| 2.8.3        |       26.0       |   ✅    |
+| 2.8.3        |       26.3       |   ✅    |
+| 3.0          |       26.0       |   ✅    |
+| 3.0          |       26.3       |   ✅    |
+| 3.4          |       26.0       |   ✅    |
+| 3.4          |       26.3       |   ✅    |
+| 3.5          |       26.0       |   ✅    |
+| 3.5          |       26.3       |   ✅    |
+| 3.8          |       26.0       |   ✅    |
+| 3.8          |       26.3       |   ✅    |
+| 3.9.1        |       26.0       |   ✅    |
+| 3.9.1        |       26.3       |   ✅    |
 
 ## Installation
 
@@ -88,7 +88,7 @@ luarocks install kong-plugin-jwt-keycloak
 #### Packing the rock
 
 ```bash
-export PLUGIN_VERSION=1.7.0-1
+export PLUGIN_VERSION=1.8.0-1
 luarocks make
 luarocks pack kong-plugin-jwt-keycloak ${PLUGIN_VERSION}
 ```
@@ -96,7 +96,7 @@ luarocks pack kong-plugin-jwt-keycloak ${PLUGIN_VERSION}
 #### Installing the rock
 
 ```bash
-export PLUGIN_VERSION=1.7.0-1
+export PLUGIN_VERSION=1.8.0-1
 luarocks install jwt-keycloak-${PLUGIN_VERSION}.all.rock
 ```
 
@@ -148,7 +148,7 @@ curl -X POST http://localhost:8001/plugins \
 ### Parameters
 
 | Parameter                              | Requied | Default           | Description                                                                                                                                                                                                                                                                                                                                                                              |
-|----------------------------------------|---------|-------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| -------------------------------------- | ------- | ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | name                                   | yes     |                   | The name of the plugin to use, in this case `keycloak-jwt`.                                                                                                                                                                                                                                                                                                                              |
 | service_id                             | semi    |                   | The id of the Service which this plugin will target.                                                                                                                                                                                                                                                                                                                                     |
 | route_id                               | semi    |                   | The id of the Route which this plugin will target.                                                                                                                                                                                                                                                                                                                                       |
@@ -160,10 +160,10 @@ curl -X POST http://localhost:8001/plugins \
 | config.run_on_preflight                | no      | `true`            | A boolean value that indicates whether the plugin should run (and try to authenticate) on `OPTIONS` preflight requests, if set to false then `OPTIONS` requests will always be allowed.                                                                                                                                                                                                  |
 | config.header_names                    | no      | `authorization`   | A list of HTTP header names that Kong will inspect to retrieve JWTs. `OPTIONS` requests will always be allowed.                                                                                                                                                                                                                                                                          |
 | config.maximum_expiration              | no      | `0`               | An integer limiting the lifetime of the JWT to `maximum_expiration` seconds in the future. Any JWT that has a longer lifetime will rejected (HTTP 403). If this value is specified, `exp` must be specified as well in the `claims_to_verify` property. The default value of `0` represents an indefinite period. Potential clock skew should be considered when configuring this value. |
-| config.algorithm                       | no      | `RS256`           | **Deprecated - No longer used.** The plugin now automatically validates that the JWT algorithm (`alg` header) is one of the supported algorithms: `RS256`, `RS384`, `RS512`, `ES256`, `ES384`, or `ES512`. This field is kept for backwards compatibility but has no effect.                                                                                                            |
+| config.algorithm                       | no      | `RS256`           | **Deprecated - No longer used.** The plugin now automatically validates that the JWT algorithm (`alg` header) is one of the supported algorithms: `RS256`, `RS384`, `RS512`, `ES256`, `ES384`, or `ES512`. This field is kept for backwards compatibility but has no effect.                                                                                                             |
 | config.allowed_iss                     | yes     |                   | A list of allowed issuers for this route/service/api. Can be specified as a `string` or as a [Pattern](http://lua-users.org/wiki/PatternsTutorial).                                                                                                                                                                                                                                      |
 | config.iss_key_grace_period            | no      | `10`              | An integer that sets the number of seconds until public keys for an issuer can be updated after writing new keys to the cache. This is a guard so that the Kong cache will not invalidate every time a token signed with an invalid public key is sent to the plugin.                                                                                                                    |
-| config.well_known_template             | false   | *see description* | A string template that the well known endpoint for keycloak is created from. String formatting is applied on the template and `%s` is replaced by the issuer of the token. Default value is `%s/.well-known/openid-configuration`                                                                                                                                                        |
+| config.well_known_template             | false   | _see description_ | A string template that the well known endpoint for keycloak is created from. String formatting is applied on the template and `%s` is replaced by the issuer of the token. Default value is `%s/.well-known/openid-configuration`                                                                                                                                                        |
 | config.scope                           | no      |                   | A list of scopes the token must have to access the api, i.e. `["email"]`. The token only has to have one of the listed scopes to be authorized.                                                                                                                                                                                                                                          |
 | config.roles                           | no      |                   | A list of roles of current client the token must have to access the api, i.e. `["uma_protection"]`. The token only has to have one of the listed roles to be authorized.                                                                                                                                                                                                                 |
 | config.realm_roles                     | no      |                   | A list of realm roles (`realm_access`) the token must have to access the api, i.e. `["offline_access"]`. The token only has to have one of the listed roles to be authorized.                                                                                                                                                                                                            |
@@ -187,7 +187,7 @@ curl -X POST http://localhost:8001/services/httpbin-anything/plugins \
     --data "config.allowed_iss=http://localhost:8080/auth/realms/master"
 
 curl -X POST http://localhost:8001/services/httpbin-anything/routes \
-    --data "paths=/" 
+    --data "paths=/"
 ```
 
 Then you can call the API:
@@ -228,7 +228,7 @@ for some reason the plugin is unable to access these endpoints.
 
 Requires:
 
-* docker
+- docker
 
 ### Setup before tests
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ x-kong-image: &kong-image
     dockerfile: Dockerfile
     args:
       KONG_VERSION: ${KONG_VERSION:-3.9.1}
-      PLUGIN_VERSION: 1.7.0-1
+      PLUGIN_VERSION: 1.8.0-1
   environment:
     KONG_DATABASE: postgres
     KONG_PG_HOST: postgres

--- a/kong-plugin-jwt-keycloak-1.7.0-1.rockspec.license
+++ b/kong-plugin-jwt-keycloak-1.7.0-1.rockspec.license
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2025 Deutsche Telekom AG
-
-SPDX-License-Identifier: Apache-2.0

--- a/kong-plugin-jwt-keycloak-1.8.0-1.rockspec
+++ b/kong-plugin-jwt-keycloak-1.8.0-1.rockspec
@@ -1,6 +1,6 @@
 local plugin_name = "jwt-keycloak"
 local package_name = "kong-plugin-" .. plugin_name
-local package_version = "1.7.0"
+local package_version = "1.8.0"
 local rockspec_revision = "1"
 
 local github_account_name = "telekom"

--- a/kong-plugin-jwt-keycloak-1.8.0-1.rockspec.license
+++ b/kong-plugin-jwt-keycloak-1.8.0-1.rockspec.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2025-2026 Deutsche Telekom AG
+
+SPDX-License-Identifier: Apache-2.0

--- a/spec/helpers.lua
+++ b/spec/helpers.lua
@@ -100,13 +100,15 @@ local mock_cjson_safe = {
           {
             kid = "kid1",
             kty = "RSA",
-            n = "0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtmY7sFdl7oahqT_Rc59oKHM78bF8HGmKuHqUL6v3Ohl80UR8QFN5Y8o3h8DGf9LUz0p8H2I",
+            n =
+            "0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtmY7sFdl7oahqT_Rc59oKHM78bF8HGmKuHqUL6v3Ohl80UR8QFN5Y8o3h8DGf9LUz0p8H2I",
             e = "AQAB"
           },
           {
             kid = "kid2",
             kty = "RSA",
-            n = "0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtmY7sFdl7oahqT_Rc59oKHM78bF8HGmKuHqUL6v3Ohl80UR8QFN5Y8o3h8DGf9LUz0p8H2I",
+            n =
+            "0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtmY7sFdl7oahqT_Rc59oKHM78bF8HGmKuHqUL6v3Ohl80UR8QFN5Y8o3h8DGf9LUz0p8H2I",
             e = "AQAB"
           }
         }
@@ -122,55 +124,25 @@ local mock_cjson_safe = {
   end
 }
 
--- Mock socket modules
-local function http_request_mock(options)
-  local url = options.url
-  local sink = options.sink
-
-  local body
-  if url and url:find("openid%-configuration") then
-    body = '{"jwks_uri": "https://keycloak.example.com/auth/realms/test/jwks"}'
-  elseif url and url:find("jwks") then
-    body = '{"keys": []}' -- actual keys are provided by mock_cjson_safe.decode
-  else
-    body = '{"test": "data"}'
-  end
-
-  if sink then
-    local writer = sink
-    writer(body)
-  end
-
-  return true, 200
-end
-
-local mock_http = {
-  request = http_request_mock
-}
-
-local mock_https = {
-  request = http_request_mock
-}
-
-local mock_ltn12 = {
-  sink = {
-    table = function(chunks)
-      return function(data)
-        table.insert(chunks, data)
-      end
+-- Mock resty.http module
+local mock_resty_http_instance = {
+  set_timeouts = function(self, connect, send, read) end,
+  request_uri = function(self, request_url, opts)
+    local body
+    if request_url and request_url:find("openid%-configuration") then
+      body = '{"jwks_uri": "https://keycloak.example.com/auth/realms/test/jwks"}'
+    elseif request_url and request_url:find("jwks") then
+      body = '{"keys": []}' -- actual keys are provided by mock_cjson_safe.decode
+    else
+      body = '{"test": "data"}'
     end
-  }
+    return { status = 200, body = body }, nil
+  end
 }
 
--- Mock url parser
-local mock_url = {
-  parse = function(url)
-    local scheme = url:match("^([^:]+):")
-    local port = scheme == "https" and 443 or 80
-    return {
-      scheme = scheme,
-      port = port
-    }
+local mock_resty_http = {
+  new = function()
+    return mock_resty_http_instance, nil
   end
 }
 
@@ -183,19 +155,13 @@ local mock_errlog = {
 }
 
 function helpers.setup_socket_mocks()
-  package.loaded["socket.http"] = mock_http
-  package.loaded["ssl.https"] = mock_https
-  package.loaded["ltn12"] = mock_ltn12
-  package.loaded["socket.url"] = mock_url
+  package.loaded["resty.http"] = mock_resty_http
   package.loaded["cjson.safe"] = mock_cjson_safe
   package.loaded["ngx.errlog"] = mock_errlog
 end
 
 function helpers.teardown_socket_mocks()
-  package.loaded["socket.http"] = nil
-  package.loaded["ssl.https"] = nil
-  package.loaded["ltn12"] = nil
-  package.loaded["socket.url"] = nil
+  package.loaded["resty.http"] = nil
   package.loaded["cjson.safe"] = nil
   package.loaded["ngx.errlog"] = nil
 end

--- a/src/keycloak_keys.lua
+++ b/src/keycloak_keys.lua
@@ -2,41 +2,39 @@
 --
 -- SPDX-License-Identifier: Apache-2.0
 
-local url = require "socket.url"
-local http = require "socket.http"
-local https = require "ssl.https"
+local http = require "resty.http"
 local cjson_safe = require "cjson.safe"
 local convert = require "kong.plugins.jwt-keycloak.key_conversion"
 
-local function get_request(url, scheme, port)
-    local req
-    if scheme == "https" then
-        req = https.request
-    else
-        req = http.request
+local DEFAULT_TIMEOUT = 10000 -- 10 seconds (connect, send, read)
+
+local function get_request(request_url)
+    local httpc, err = http.new()
+    if not httpc then
+        return nil, 'Failed to create HTTP client: ' .. (err or 'unknown')
     end
 
-    local res
-    local status
-    local err
+    httpc:set_timeouts(DEFAULT_TIMEOUT, DEFAULT_TIMEOUT, DEFAULT_TIMEOUT)
 
-    local chunks = {}
-    res, status = req{
-        url = url,
-        port = port,
-        sink = ltn12.sink.table(chunks)
-    }
-    
-    if status ~= 200 then
-        return nil, 'Failed calling url ' .. url .. ' response status ' .. status
-    end
+    local res, req_err = httpc:request_uri(request_url, {
+        method = "GET",
+        ssl_verify = false,
+    })
 
-    res, err = cjson_safe.decode(table.concat(chunks))
     if not res then
+        return nil, 'Failed calling url ' .. request_url .. ': ' .. (req_err or 'unknown')
+    end
+
+    if res.status ~= 200 then
+        return nil, 'Failed calling url ' .. request_url .. ' response status ' .. res.status
+    end
+
+    local body, decode_err = cjson_safe.decode(res.body)
+    if not body then
         return nil, 'Failed to parse json response'
     end
-    
-    return res, nil
+
+    return body, nil
 end
 
 local function get_wellknown_endpoint(well_known_template, issuer)
@@ -44,15 +42,12 @@ local function get_wellknown_endpoint(well_known_template, issuer)
 end
 
 local function get_issuer_keys(well_known_endpoint)
-    -- Get port of the request: This is done because keycloak 3.X.X does not play well with lua socket.http
-    local req = url.parse(well_known_endpoint)
-
-    local res, err = get_request(well_known_endpoint, req.scheme, req.port)
+    local res, err = get_request(well_known_endpoint)
     if err then
         return nil, nil, err
     end
 
-    local jwks, jwks_err = get_request(res["jwks_uri"], req.scheme, req.port)
+    local jwks, jwks_err = get_request(res["jwks_uri"])
     if jwks_err then
         return nil, nil, jwks_err
     end


### PR DESCRIPTION
## Replace blocking `socket.http` with non-blocking `resty.http` for JWKS fetching

### Summary

This change migrates the HTTP client used for fetching issuer public keys (JWKS) from LuaSocket's blocking `socket.http`/`ssl.https` to OpenResty's cosocket-based `resty.http`. This eliminates a significant operational risk where a slow or unresponsive Keycloak instance could stall entire Kong worker processes.

### Problem

The plugin fetches public keys from the token issuer's `.well-known/openid-configuration` and JWKS endpoints to verify JWT signatures. The previous implementation used `socket.http` and `ssl.https`, which are **blocking I/O** libraries. When these calls blocked (e.g. due to an unreachable Keycloak, network partition, or DNS issue), the entire nginx worker was unable to serve any other requests for the duration of the timeout — up to **60 seconds** (LuaSocket's default, which was never explicitly configured).

In a deployment with limited worker processes, a single unresponsive issuer endpoint could effectively take down the gateway.

### Changes

**`src/keycloak_keys.lua`**
- Replaced `socket.http`, `ssl.https`, and `socket.url` imports with a single `resty.http` import
- Rewrote `get_request()` to use `resty.http:request_uri()`, which handles URL parsing, scheme detection (HTTP/HTTPS), and TLS negotiation internally
- Added an explicit **10-second timeout** for connect, send, and read operations (`DEFAULT_TIMEOUT = 10000`)
- Simplified `get_issuer_keys()` by removing the manual `url.parse()` call that was only needed to work around LuaSocket's port handling for older Keycloak versions
- Removed the `ltn12` dependency (was used for LuaSocket's sink-based response buffering)

**`spec/helpers.lua`**
- Replaced mocks for `socket.http`, `ssl.https`, `ltn12`, and `socket.url` with a single `resty.http` mock that implements `new()`, `set_timeouts()`, and `request_uri()`

### Technical details

- **Non-blocking I/O**: `resty.http` uses OpenResty's cosocket API, which yields the current coroutine while waiting for network I/O. Other requests continue to be served by the same worker during the wait. This is the standard approach used by Kong's own bundled plugins.
- **Explicit timeouts**: The previous code relied on LuaSocket's implicit 60-second default. The new code sets a 10-second timeout for each phase (connect, send, read), providing faster failure detection and reducing the blast radius of issuer outages.
- **TLS handling**: The old code used separate libraries for HTTP and HTTPS with no certificate verification. The new code uses `resty.http` for both schemes with `ssl_verify = false`, preserving the existing behavior. Enabling `ssl_verify = true` in a follow-up is recommended — `resty.http` will then verify against Kong's globally configured `lua_ssl_trusted_certificate` trust store.
- **No changes to `handler.lua`**: The function signatures for `get_request` and `get_issuer_keys` changed (removed `scheme`/`port` parameters), but `handler.lua` only calls `get_issuer_keys` via `custom_helper_issuer_get_keys`, which continues to work without modification.
- **`conf.cafile`**: This config parameter was already a dead parameter in the old implementation — it was passed through from `handler.lua` but never forwarded to the HTTP calls. This remains unchanged.

### Testing

All existing unit and integration tests pass across the CI matrix (Kong 2.8.3 through 3.9.1, Keycloak 26.0 and 26.3).