### PR TITLE
feat: add JWT_KEYCLOAK_BLOCKED_ISSUERS zone-wide issuer blocklist

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ RUN if [ -x "$(command -v apk)" ]; then apk add --no-cache $FIX_DEPENDENCIES; \
     elif [ -x "$(command -v apt-get)" ]; then apt-get remove --purge -y $FIX_DEPENDENCIES; \
     fi
 
-ARG PLUGIN_VERSION=1.7.0-1
+ARG PLUGIN_VERSION=1.8.0-1
 RUN luarocks install /tmp/kong-plugin-jwt-keycloak-${PLUGIN_VERSION}.all.rock
 
 USER kong

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ x-kong-image: &kong-image
     dockerfile: Dockerfile
     args:
       KONG_VERSION: ${KONG_VERSION:-3.9.1}
-      PLUGIN_VERSION: 1.7.0-1
+      PLUGIN_VERSION: 1.8.0-1
   environment:
     KONG_DATABASE: postgres
     KONG_PG_HOST: postgres

--- a/kong-plugin-jwt-keycloak-1.7.0-1.rockspec.license
+++ b/kong-plugin-jwt-keycloak-1.7.0-1.rockspec.license
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2025 Deutsche Telekom AG
-
-SPDX-License-Identifier: Apache-2.0

--- a/kong-plugin-jwt-keycloak-1.8.0-1.rockspec
+++ b/kong-plugin-jwt-keycloak-1.8.0-1.rockspec
@@ -1,6 +1,10 @@
+-- SPDX-FileCopyrightText: 2025 Deutsche Telekom AG
+--
+-- SPDX-License-Identifier: Apache-2.0
+
 local plugin_name = "jwt-keycloak"
 local package_name = "kong-plugin-" .. plugin_name
-local package_version = "1.7.0"
+local package_version = "1.8.0"
 local rockspec_revision = "1"
 
 local github_account_name = "telekom"

--- a/spec/01-unit/validators/issuers_spec.lua
+++ b/spec/01-unit/validators/issuers_spec.lua
@@ -3,6 +3,7 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 local validate_issuer = require("kong.plugins.jwt-keycloak.validators.issuers").validate_issuer
+local is_issuer_blocked = require("kong.plugins.jwt-keycloak.validators.issuers").is_issuer_blocked
 
 describe("Plugin: jwt-keycloak (issuers validator)", function()
   describe("validate_issuer", function()
@@ -76,4 +77,56 @@ describe("Plugin: jwt-keycloak (issuers validator)", function()
       assert.equals("Allowed issuers is empty", err)
     end)
   end)
+
+  describe("is_issuer_blocked", function()
+    it("should not block when blocked_issuers is nil", function()
+      local result = is_issuer_blocked(nil, "https://keycloak.example.com/auth/realms/test")
+
+      assert.is_false(result)
+    end)
+
+    it("should not block when iss is nil", function()
+      local blocked_issuers = {"https://compromised.example.com/auth/realms/default"}
+
+      local result = is_issuer_blocked(blocked_issuers, nil)
+
+      assert.is_false(result)
+    end)
+
+    it("should not block when blocked list is empty", function()
+      local blocked_issuers = {}
+
+      local result = is_issuer_blocked(blocked_issuers, "https://keycloak.example.com/auth/realms/test")
+
+      assert.is_false(result)
+    end)
+
+    it("should block on exact match", function()
+      local blocked_issuers = {"https://compromised.example.com/auth/realms/default"}
+
+      local result = is_issuer_blocked(blocked_issuers, "https://compromised.example.com/auth/realms/default")
+
+      assert.is_true(result)
+    end)
+
+    it("should not block when iss does not match any entry", function()
+      local blocked_issuers = {"https://compromised.example.com/auth/realms/default"}
+
+      local result = is_issuer_blocked(blocked_issuers, "https://legitimate.example.com/auth/realms/default")
+
+      assert.is_false(result)
+    end)
+
+    it("should block when iss matches a non-first entry", function()
+      local blocked_issuers = {
+        "https://other-compromised.example.com/auth/realms/default",
+        "https://compromised.example.com/auth/realms/default",
+      }
+
+      local result = is_issuer_blocked(blocked_issuers, "https://compromised.example.com/auth/realms/default")
+
+      assert.is_true(result)
+    end)
+  end)
 end)
+

--- a/src/handler.lua
+++ b/src/handler.lua
@@ -10,6 +10,7 @@ local keycloak_keys = require("kong.plugins.jwt-keycloak.keycloak_keys")
 local plugin_schema = require("kong.plugins.jwt-keycloak.schema")
 
 local validate_issuer = require("kong.plugins.jwt-keycloak.validators.issuers").validate_issuer
+local is_issuer_blocked = require("kong.plugins.jwt-keycloak.validators.issuers").is_issuer_blocked
 local validate_scope = require("kong.plugins.jwt-keycloak.validators.scope").validate_scope
 local validate_roles = require("kong.plugins.jwt-keycloak.validators.roles").validate_roles
 local validate_realm_roles = require("kong.plugins.jwt-keycloak.validators.roles").validate_realm_roles
@@ -30,6 +31,16 @@ else
     priority = 1005
 end
 kong.log.debug('JWT_KEYCLOAK_PRIORITY: ' .. priority)
+
+local blocked_issuers_env_var = "JWT_KEYCLOAK_BLOCKED_ISSUERS"
+local BLOCKED_ISSUERS = {}
+local raw_blocked = os.getenv(blocked_issuers_env_var)
+if raw_blocked and raw_blocked ~= "" then
+    for entry in raw_blocked:gmatch("[^,]+") do
+        BLOCKED_ISSUERS[#BLOCKED_ISSUERS + 1] = entry:match("^%s*(.-)%s*$")
+    end
+end
+kong.log.debug('JWT_KEYCLOAK_BLOCKED_ISSUERS count: ' .. #BLOCKED_ISSUERS)
 
 local JwtKeycloakHandler = {
     VERSION = kong_meta.version,
@@ -439,6 +450,16 @@ local function do_authentication(conf)
         return false, {
             status = 401,
             message = "Bad token; " .. tostring(jwt_err)
+        }
+    end
+
+    -- Check zone-wide issuer blocklist (set at deploy time via JWT_KEYCLOAK_BLOCKED_ISSUERS
+    -- as an emergency measure to block compromised consumer zone gateway issuers)
+    if is_issuer_blocked(BLOCKED_ISSUERS, jwt.claims.iss) then
+        security_event('ua222', 'ua, issuer is blocked')
+        return false, {
+            status = 401,
+            message = "Token issuer is blocked"
         }
     end
 

--- a/src/handler.lua
+++ b/src/handler.lua
@@ -438,7 +438,7 @@ local function do_authentication(conf)
         security_event('ua201', 'ua, token integrity wrong')
         return false, {
             status = 401,
-            message = "Bad token; " .. tostring(err)
+            message = "Bad token; " .. tostring(jwt_err)
         }
     end
 

--- a/src/validators/issuers.lua
+++ b/src/validators/issuers.lua
@@ -17,6 +17,24 @@ local function validate_issuer(allowed_issuers, jwt_claims)
     return nil, "Token issuer not allowed"
 end
 
+-- Checks whether a token's iss claim matches any entry in the blocked_issuers list.
+-- Uses exact match only — unlike allowed_issuers, entries are not treated as Lua
+-- patterns. This is an emergency measure — JWT_KEYCLOAK_BLOCKED_ISSUERS can be set
+-- to plain URLs without knowledge of Lua pattern syntax, and exact match avoids silent over-blocking from
+-- unescaped magic characters (e.g. dots) in URLs.
+-- Returns false for a nil iss or nil/empty blocked_issuers — a missing issuer claim
+-- is not treated as blocked; it will be rejected downstream by validate_issuer.
+local function is_issuer_blocked(blocked_issuers, iss)
+    if not blocked_issuers or iss == nil then return false end
+    for _, blocked in ipairs(blocked_issuers) do
+        if blocked == iss then
+            return true
+        end
+    end
+    return false
+end
+
 return {
-    validate_issuer = validate_issuer
+    validate_issuer = validate_issuer,
+    is_issuer_blocked = is_issuer_blocked,
 }


### PR DESCRIPTION
## Context

The Mesh LMS feature (DHEI-19942 / PR #103 in gateway-jumper) replaces the Iris `gateway` client-credentials token used for cross-zone mesh calls with a self-signed LMS token. The provider zone's `jwt-keycloak` plugin now trusts the consumer zone's StarGate key (listed in `allowed_iss` on proxy routes) rather than its own Iris.

This shifts the trust model: a compromised consumer zone StarGate private key can now be used to forge mesh tokens accepted by any provider zone that lists that issuer in `allowed_iss`. The primary revocation mechanism — removing the issuer from `allowed_iss` via Rover — is a per-route operation and can take significant time to propagate across all routes on a large zone.

## What This PR Adds

A zone-wide emergency issuer blocklist. `JWT_KEYCLOAK_BLOCKED_ISSUERS` can be set to a comma-separated list of issuer URLs at deploy time; any token whose `iss` claim matches an entry is rejected with 401 immediately, before any per-route `allowed_iss` check. This allows a compromised issuer to be blocked zone-wide in a single redeploy, without waiting for Rover to reprocess every affected proxy route.

**Key design decisions:**
- Read once at worker startup (same pattern as `JWT_KEYCLOAK_PRIORITY`) — requires a Kong redeploy to update, which is intentional
- Exact match only (no Lua patterns) — this is an emergency measure; pattern syntax would be a footgun with unescaped URL characters
- Blocklist check runs before `allowed_iss` validation — blocked wins over allowed
- Comma-separated list of issuer URLs; entries are whitespace-trimmed

## Changes

- `src/validators/issuers.lua` — new `is_issuer_blocked(blocked_issuers, iss)` function (exact match)
- `src/handler.lua` — reads `JWT_KEYCLOAK_BLOCKED_ISSUERS` at module load; calls `is_issuer_blocked` before `validate_issuer` in `do_authentication`
- `spec/01-unit/validators/issuers_spec.lua` — unit tests for `is_issuer_blocked`
- `kong-plugin-jwt-keycloak-1.8.0-1.rockspec` — version bump from 1.7.0, inline SPDX header (replaces sidecar `.license` file)

Also includes a pre-existing bug fix: `fix: use jwt_err instead of nil err in bad token message` (committed separately).

## Usage

```bash
# Block a compromised consumer zone issuer zone-wide
JWT_KEYCLOAK_BLOCKED_ISSUERS="https://stargate-cetus.preprod.tardis.telekom.de/auth/realms/default"

# Multiple issuers (comma-separated)
JWT_KEYCLOAK_BLOCKED_ISSUERS="https://stargate-cetus.preprod.tardis.telekom.de/auth/realms/default,https://stargate-aws.preprod.tardis.telekom.de/auth/realms/default"
```

DHEI-19943