### PR TITLE
chore(deps): bump Kong version 3.9.1 -> 3.9.3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        kong_version: ["2.8.3", "3.0", "3.4", "3.5", "3.8", "3.9.1"]
+        kong_version: ["2.8.3", "3.0", "3.4", "3.5", "3.8", "3.9.1", "3.9.3"]
         keycloak_version: ["26.0", "26.3"]
       fail-fast: false
     env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ## Build plugin
-ARG KONG_VERSION=3.9.1
+ARG KONG_VERSION=3.9.3
 
 FROM docker.io/kong:${KONG_VERSION} AS builder
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ There are a few limitations about testing combinations:
 | 3.8          |       26.3       |    ✅    |
 | 3.9.1        |       26.0       |    ✅    |
 | 3.9.1        |       26.3       |    ✅    |
+| 3.9.3        |       26.0       |    ✅    |
+| 3.9.3        |       26.3       |    ✅    |
 
 ## Installation
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ x-kong-image: &kong-image
     context: .
     dockerfile: Dockerfile
     args:
-      KONG_VERSION: ${KONG_VERSION:-3.9.1}
+      KONG_VERSION: ${KONG_VERSION:-3.9.3}
       PLUGIN_VERSION: 1.8.1-1
   environment:
     KONG_DATABASE: postgres


### PR DESCRIPTION
## Summary
- Bump default `KONG_VERSION` in `Dockerfile` and `docker-compose.yml` from 3.9.1 to 3.9.3
- Extend the "Tested and working for" table in README with 3.9.3 (Keycloak 26.0 / 26.3)
- Add 3.9.3 to the CI test matrix in `.github/workflows/test.yml`

## Context
Follow-up to review feedback from Luis on telekom/gateway-kong-image#27, which bumped the Kong base image in the main `gateway-kong-image` to 3.9.3 but left this submodule's own Dockerfile/compose/CI pinned to 3.9.1.

## Testing
Verified locally (not just relying on CI) via:
```
KONG_VERSION=3.9.3 KEYCLOAK_VERSION=26.0 docker compose up --build --exit-code-from tests tests
KONG_VERSION=3.9.3 KEYCLOAK_VERSION=26.3 docker compose up --build --exit-code-from tests tests
```
Both combinations pass (exit code 0), matching the ✅ added to the README table.